### PR TITLE
Add default rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google_apps (0.5)
+    google_apps (0.9)
       httparty
       libxml-ruby (>= 2.2.2)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+#!/usr/bin/env rake
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+#require 'rake'
+#
+#if ['test', 'development'].include?(ENV['RACK_ENV'])
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+#end

--- a/google_apps.gemspec
+++ b/google_apps.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split("\n")
   spec.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  spec.test_files << 'Rakefile'
 end


### PR DESCRIPTION
Making specs to run when I type `rake` at the command line. Exclude Rakefile from final gem construction
